### PR TITLE
Add `rickroll`

### DIFF
--- a/moexe/rickroll.moexe
+++ b/moexe/rickroll.moexe
@@ -1,0 +1,3 @@
+shell curl https://raw.githubusercontent.com/Mwalters75/rickroll-gtk/main/rickroll-gtk.py -O rickroll-gtk.py
+shell python3 rickroll-gtk.py
+shell rm -rf rickroll-gtk.py


### PR DESCRIPTION
Forwards the `moexe` script to Python to run the rickroll, which is in a window.