### PR TITLE
Add `takeover`

### DIFF
--- a/python/takeover.py
+++ b/python/takeover.py
@@ -1,0 +1,11 @@
+import os
+
+usr = os.getlogin()
+home = os.getcwd()
+
+while True:
+		cmd = input("(shell)" + usr + "@" + home + ": ")
+		if(cmd == "exit"):
+			exit()
+		else:
+			print(os.system(cmd))


### PR DESCRIPTION
Takes over the MeltOS shell to go back to Bash, while MeltOS runs in the background. Easily exitable by doing `^C`.
<sup>Pretty much the first Python script, that isn't a example.</sup>